### PR TITLE
Fixed #6

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
@@ -331,9 +331,10 @@ public abstract class AbstractGrid extends NetworkObject {
 
     @Nonnull
     private static List<String> getLoreAddition(int amount) {
+        final MessageFormat format = new MessageFormat("{0}Amount: {1}{2}", Locale.ROOT);
         return List.of(
             "",
-            MessageFormat.format("{0}Amount: {1}{2}", Theme.CLICK_INFO.getColor(), Theme.PASSIVE.getColor(), amount)
+            format.format(new Object[] { Theme.CLICK_INFO.getColor(), Theme.PASSIVE.getColor(), amount }, new StringBuffer(), null).toString()
         );
     }
 }


### PR DESCRIPTION
When using `java.text.MessageFormat`, you also need to specify a `Locale` object, otherwise it may try to format things in non-english ways.

Haven't tested this, just saw the issue and immediately spotted the problem.
If you want to improve performance, you can also define the `MessageFormat` on the class level.
This way, it won't need to be created everytime the method is called.

Just a side note: The static `MessageFormat.format` method does the exact same that I am doing here (excluding the `Locale` specification). Therefore you were already allocating a `MessageFormat` on every invocation anyway.