### PR TITLE
Fix duplication bug

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
@@ -146,7 +146,7 @@ public abstract class AbstractGrid extends NetworkObject {
         final NodeDefinition definition = NetworkStorage.getAllNetworkObjects().get(blockMenu.getLocation());
 
         // No node located, weird
-        if (definition.getNode() == null) {
+        if (definition == null || definition.getNode() == null) {
             clearDisplay(blockMenu);
             return;
         }


### PR DESCRIPTION
I am not sure how to replicate this bug, but a player of mine was able to duplicate items with a network with what I can only assume was a hacked client.

His setup consisted of the following:
- A network grid
- A network controller
- A network monitor monitoring a Basic Storage Unit from the Infinity Expansion

He would put a single shulker box (presumably this can be any item? maybe only unstackable items?) into the storage unit and proceed to break and replace the network grid over and over again (from what I could see). I assume he was also somehow clicking in the grid GUI at the same time, which is why I was not able to reproduce the bug and suspect that he was using a hacked client. Every time he broke the grid, the console would encounter the following error:
```
[00:46:43] [Server thread/ERROR]: Could not pass event InventoryClickEvent to Slimefun vDEV - 1027 (git 96c873bd)
java.lang.NullPointerException: Cannot invoke "io.github.sefiraat.networks.network.NodeDefinition.getNode()" because "definition" is null
	at io.github.sefiraat.networks.slimefun.network.grid.AbstractGrid.updateDisplay(AbstractGrid.java:149) ~[Networks - DEV 44 (git 2e7bc).jar:?]
	at io.github.sefiraat.networks.slimefun.network.grid.AbstractGrid.retrieveItem(AbstractGrid.java:281) ~[Networks - DEV 44 (git 2e7bc).jar:?]
	at io.github.sefiraat.networks.slimefun.network.grid.AbstractGrid.lambda$updateDisplay$1(AbstractGrid.java:196) ~[Networks - DEV 44 (git 2e7bc).jar:?]
	at me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.MenuListener.onClick(MenuListener.java:56) ~[Slimefun4 - DEV 1026 (git 85e8f).jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor357.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-138]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3306) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:58) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:23) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1361) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1338) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1331) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:114) ~[?:?]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1465) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1193) ~[paper-1.19.2.jar:git-Paper-138]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:305) ~[paper-1.19.2.jar:git-Paper-138]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
After looking through the code, it is immediately apparent that `definition` is null in this case and the map did not contain the block's location (since it had just been broken). I simply check that the definition is null first, and this fixes the duplication. Though I was not able to confirm it myself, it was a pretty definitive answer from the user exploiting the bug. When the user came back onto the server and tried again, he could not get it to work no matter how hard he tried. Therefore, I believe that this edit fixes the error and the duplication glitch.