### PR TITLE
Check Backpack Check to an Instance Of Check

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/network/SupportedRecipes.java
+++ b/src/main/java/io/github/sefiraat/networks/network/SupportedRecipes.java
@@ -53,8 +53,8 @@ public final class SupportedRecipes {
         return true;
     }
 
-    public static boolean allowedRecipe(@Nonnull SlimefunItem i) {
-        return !(i instanceof SlimefunBackpack);
+    public static boolean allowedRecipe(@Nonnull SlimefunItem item) {
+        return !(item instanceof SlimefunBackpack);
     }
 
 }

--- a/src/main/java/io/github/sefiraat/networks/network/SupportedRecipes.java
+++ b/src/main/java/io/github/sefiraat/networks/network/SupportedRecipes.java
@@ -2,9 +2,9 @@ package io.github.sefiraat.networks.network;
 
 import io.github.sefiraat.networks.utils.StackUtils;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import lombok.experimental.UtilityClass;
 import org.bukkit.inventory.ItemStack;
 
@@ -53,20 +53,8 @@ public final class SupportedRecipes {
         return true;
     }
 
-    public static boolean allowedRecipe(@Nonnull SlimefunItemStack i) {
-        return allowedRecipe(i.getItemId());
-    }
-
-    public static boolean allowedRecipe(@Nonnull String s) {
-        return !isBackpack(s);
-    }
-
-    public static boolean isBackpack(@Nonnull String s) {
-        return s.matches("(.*)BACKPACK(.*)");
-    }
-
     public static boolean allowedRecipe(@Nonnull SlimefunItem i) {
-        return allowedRecipe(i.getId());
+        return !(i instanceof SlimefunBackpack);
     }
 
 }


### PR DESCRIPTION
This PR changes the check in `SupportedRecipes.java` to use an `instanceof` check instead of checking a regex on the id. It checks if the Slimefun item is an instance of a SlimefunBackpack.

I have not tested the changes but will send a message here when I do