### PR TITLE
Add SlimeFrame support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.sefiraat</groupId>
     <artifactId>networks</artifactId>
-    <version>MODIFIED_1.2.0</version>
+    <version>MODIFIED_1.3.0</version>
 
     <distributionManagement>
         <repository>
@@ -194,6 +194,12 @@
             <groupId>com.github.Sefiraat</groupId>
             <artifactId>Netheopoiesis</artifactId>
             <version>8d1af6c570</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.voper</groupId>
+            <artifactId>SlimeFrame</artifactId>
+            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/sefiraat/networks/managers/SupportedPluginManager.java
+++ b/src/main/java/io/github/sefiraat/networks/managers/SupportedPluginManager.java
@@ -10,6 +10,7 @@ public class SupportedPluginManager {
 
     private final boolean infinityExpansion;
     private final boolean netheopoiesis;
+    private final boolean slimeFrame;
 
     // region First Tick Only Registrations
     private boolean mcMMO;
@@ -22,6 +23,7 @@ public class SupportedPluginManager {
         instance = this;
         this.infinityExpansion = Bukkit.getPluginManager().isPluginEnabled("InfinityExpansion");
         this.netheopoiesis = Bukkit.getPluginManager().isPluginEnabled("Netheopoiesis");
+        this.slimeFrame = Bukkit.getPluginManager().isPluginEnabled("SlimeFrame");
         Networks.getInstance()
             .getServer()
             .getScheduler()
@@ -39,6 +41,10 @@ public class SupportedPluginManager {
 
     public boolean isNetheopoiesis() {
         return netheopoiesis;
+    }
+
+    public boolean isSlimeFrame() {
+        return slimeFrame;
     }
 
     public boolean isMcMMO() {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
@@ -20,6 +20,7 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.voper.slimeframe.SlimeFrame;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -125,6 +126,9 @@ public class NetworkControlV extends NetworkDirectional {
             targetBlock.setType(fetchedStack.getType(), true);
             if (SupportedPluginManager.getInstance().isMcMMO()) {
                 mcMMO.getPlaceStore().setTrue(targetBlock);
+            }
+            if (SupportedPluginManager.getInstance().isSlimeFrame()) {
+                SlimeFrame.getPlacedBlocks().add(targetBlock);
             }
             ParticleUtils.displayParticleRandomly(
                 LocationUtils.centre(targetBlock.getLocation()),

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,7 @@ softdepend:
   - InfinityExpansion
   - Netheopoiesis
   - WildChests
+  - SlimeFrame
 commands:
   networks:
     description: /networks


### PR DESCRIPTION
This commit basically adds support to SlimeFrame so every block pasted by the NetworkControlIV will be added to a set inside SlimeFrame and therefore will not be considered as naturally generated blocks.
I have tested it in my private server and it works fine.