### PR TITLE
Hotfix for the Network Control X & V

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.gmail.nossr50.mcMMO;
 import dev.sefiraat.sefilib.misc.ParticleUtils;
 import dev.sefiraat.sefilib.world.LocationUtils;
+import io.github.bakedlibs.dough.blocks.BlockPosition;
 import io.github.sefiraat.networks.NetworkStorage;
 import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.managers.SupportedPluginManager;
@@ -31,6 +32,8 @@ import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 public class NetworkControlV extends NetworkDirectional {
@@ -48,6 +51,8 @@ public class NetworkControlV extends NetworkDirectional {
     private static final int DOWN_SLOT = 32;
     private static final int REQUIRED_POWER = 100;
 
+    private final Set<BlockPosition> blockCache = new HashSet<>();
+
     public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
         Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "Paste items matching template"
     );
@@ -63,6 +68,11 @@ public class NetworkControlV extends NetworkDirectional {
         if (blockMenu != null) {
             tryPasteBlock(blockMenu);
         }
+    }
+
+    @Override
+    protected void onUniqueTick() {
+        blockCache.clear();
     }
 
     private void tryPasteBlock(@Nonnull BlockMenu blockMenu) {
@@ -83,6 +93,12 @@ public class NetworkControlV extends NetworkDirectional {
         }
 
         final Block targetBlock = blockMenu.getBlock().getRelative(direction);
+        final BlockPosition targetPosition = new BlockPosition(targetBlock);
+
+        if (this.blockCache.contains(targetPosition)) {
+            return;
+        }
+
         final Material material = targetBlock.getType();
 
         if (!material.isAir()) {
@@ -121,6 +137,7 @@ public class NetworkControlV extends NetworkDirectional {
             return;
         }
 
+        this.blockCache.add(targetPosition);
         Bukkit.getScheduler().runTask(Networks.getInstance(), bukkitTask -> {
             targetBlock.setType(fetchedStack.getType(), true);
             if (SupportedPluginManager.getInstance().isMcMMO()) {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlX.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlX.java
@@ -133,7 +133,7 @@ public class NetworkControlX extends NetworkDirectional {
         definition.getNode().getRoot().addItemStack(resultStack);
 
         if (resultStack.getAmount() == 0) {
-            this.blockCache.add(new BlockPosition(targetBlock));
+            this.blockCache.add(targetPosition);
             Bukkit.getScheduler().runTask(Networks.getInstance(), bukkitTask -> {
                 final BlockStateSnapshotResult blockState = PaperLib.getBlockState(targetBlock, true);
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
@@ -103,10 +103,10 @@ public abstract class NetworkDirectional extends NetworkObject {
 
                 @Override
                 public void uniqueTick() {
+                    tick = tick <= 1 ? tickRate.getValue() : tick - 1;
                     if (tick <= 1) {
                         onUniqueTick();
                     }
-                    tick = tick <= 1 ? tickRate.getValue() : tick - 1;
                 }
             }
         );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
@@ -103,6 +103,9 @@ public abstract class NetworkDirectional extends NetworkObject {
 
                 @Override
                 public void uniqueTick() {
+                    if (tick <= 1) {
+                        onUniqueTick();
+                    }
                     tick = tick <= 1 ? tickRate.getValue() : tick - 1;
                 }
             }
@@ -160,6 +163,8 @@ public abstract class NetworkDirectional extends NetworkObject {
         addToRegistry(block);
         updateGui(blockMenu);
     }
+
+    protected void onUniqueTick() {}
 
     @Override
     public void postRegister() {


### PR DESCRIPTION
## Why am I making this PR:
Hotfix for a bug with the `Network Control X` and the `Network Control V`
In the future an Abstract Class that takes this cache and other duplicated code could be made for the 2 classes

## What is changed:
- Adds `NetworkDirectional#onUniqueTick`
   - The implementation of this follows `NetworkDirectional#onTick`
- Adds `blockCache` to both `Network Control X` and `Network Control V`
   - This is a set of blockpositions that is added to when placing or breaking a block, and cleared on the unique tick

## Related Issues
N/A (I think? I didnt see any)