### PR TITLE
Add Smaller Quantum Storage (512)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
    build.
 2. Ensure valid annotations and JavaDocs have been added to new, public, methods and code has been commented for clarify where appropriate.
-3. Increase the version numbers in the pon.xml file to the new version that this
+3. Increase the version numbers in the pom.xml file to the new version that this
    Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
 4. You may merge the Pull Request in once you have the sign-off of one other developer, or if you 
    do not have permission to do that, you may request the reviewer to merge it for you.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.1.0</modelVersion>
     <groupId>io.github.sefiraat</groupId>
     <artifactId>networks</artifactId>
     <version>MODIFIED_1.2.0</version>

--- a/src/main/java/io/github/sefiraat/networks/commands/NetworksMain.java
+++ b/src/main/java/io/github/sefiraat/networks/commands/NetworksMain.java
@@ -25,6 +25,7 @@ public class NetworksMain implements CommandExecutor {
     private static final Map<Integer, NetworkQuantumStorage> QUANTUM_REPLACEMENT_MAP = new HashMap<>();
 
     static {
+        QUANTUM_REPLACEMENT_MAP.put(512, NetworkSlimefunItems.NETWORK_QUANTUM_STORAGE_0);
         QUANTUM_REPLACEMENT_MAP.put(4096, NetworkSlimefunItems.NETWORK_QUANTUM_STORAGE_1);
         QUANTUM_REPLACEMENT_MAP.put(32768, NetworkSlimefunItems.NETWORK_QUANTUM_STORAGE_2);
         QUANTUM_REPLACEMENT_MAP.put(262144, NetworkSlimefunItems.NETWORK_QUANTUM_STORAGE_3);

--- a/src/main/java/io/github/sefiraat/networks/slimefun/NetworkSlimefunItems.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/NetworkSlimefunItems.java
@@ -79,6 +79,7 @@ public class NetworkSlimefunItems {
     public static final NetworkCell NETWORK_CELL;
     public static final NetworkGreedyBlock NETWORK_GREEDY_BLOCK;
     public static final NetworkQuantumWorkbench NETWORK_QUANTUM_WORKBENCH;
+    public static final NetworkQuantumStorage NETWORK_QUANTUM_STORAGE_0;
     public static final NetworkQuantumStorage NETWORK_QUANTUM_STORAGE_1;
     public static final NetworkQuantumStorage NETWORK_QUANTUM_STORAGE_2;
     public static final NetworkQuantumStorage NETWORK_QUANTUM_STORAGE_3;
@@ -468,6 +469,18 @@ public class NetworkSlimefunItems {
                 OPTIC_CABLE.getItem(), NETWORK_BRIDGE.getItem(), OPTIC_CABLE.getItem(),
                 OPTIC_GLASS.getItem(), SlimefunItems.ADVANCED_CIRCUIT_BOARD, OPTIC_GLASS.getItem()
             }
+        );
+
+        NETWORK_QUANTUM_STORAGE_0 = new NetworkQuantumStorage(
+            NetworksItemGroups.NETWORK_QUANTUMS,
+            NetworksSlimefunItemStacks.NETWORK_QUANTUM_STORAGE_0,
+            NetworkQuantumWorkbench.TYPE,
+            new ItemStack[]{
+                OPTIC_GLASS.getItem(), OPTIC_GLASS.getItem(), OPTIC_GLASS.getItem(),
+                OPTIC_CABLE.getItem(), SlimefunItems.ELECTRIC_MOTOR, OPTIC_CABLE.getItem(),
+                OPTIC_GLASS.getItem(), OPTIC_GLASS.getItem(), OPTIC_GLASS.getItem()
+            },
+            NetworkQuantumStorage.getSizes()[0]
         );
 
         NETWORK_QUANTUM_STORAGE_1 = new NetworkQuantumStorage(
@@ -869,6 +882,7 @@ public class NetworkSlimefunItems {
         NETWORK_CELL.register(plugin);
         NETWORK_GREEDY_BLOCK.register(plugin);
         NETWORK_QUANTUM_WORKBENCH.register(plugin);
+        NETWORK_QUANTUM_STORAGE_0.register(plugin);
         NETWORK_QUANTUM_STORAGE_1.register(plugin);
         NETWORK_QUANTUM_STORAGE_2.register(plugin);
         NETWORK_QUANTUM_STORAGE_3.register(plugin);

--- a/src/main/java/io/github/sefiraat/networks/slimefun/NetworksSlimefunItemStacks.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/NetworksSlimefunItemStacks.java
@@ -58,6 +58,7 @@ public class NetworksSlimefunItemStacks {
     public static final SlimefunItemStack NETWORK_CELL;
     public static final SlimefunItemStack NETWORK_GREEDY_BLOCK;
     public static final SlimefunItemStack NETWORK_QUANTUM_WORKBENCH;
+    public static final SlimefunItemStack NETWORK_QUANTUM_STORAGE_0;
     public static final SlimefunItemStack NETWORK_QUANTUM_STORAGE_1;
     public static final SlimefunItemStack NETWORK_QUANTUM_STORAGE_2;
     public static final SlimefunItemStack NETWORK_QUANTUM_STORAGE_3;
@@ -436,13 +437,24 @@ public class NetworksSlimefunItemStacks {
             "Allows the crafting of Quantum Storages."
         );
 
+        NETWORK_QUANTUM_STORAGE_0 = Theme.themedSlimefunItemStack(
+            "NTW_QUANTUM_STORAGE_0",
+            new ItemStack(Material.YELLOW_TERRACOTTA),
+            Theme.MACHINE,
+            "Network Quantum Storage (512)",
+            "Stores " + NetworkQuantumStorage.getSizes()[0] + " items",
+            "",
+            "Stores items in mass quantities within",
+            "a quantum singularity."
+        );
+
 
         NETWORK_QUANTUM_STORAGE_1 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_1",
             new ItemStack(Material.WHITE_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (4K)",
-            "Stores " + NetworkQuantumStorage.getSizes()[0] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[1] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."
@@ -453,7 +465,7 @@ public class NetworksSlimefunItemStacks {
             new ItemStack(Material.LIGHT_GRAY_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (32K)",
-            "Stores " + NetworkQuantumStorage.getSizes()[1] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[2] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."
@@ -464,7 +476,7 @@ public class NetworksSlimefunItemStacks {
             new ItemStack(Material.GRAY_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (262K)",
-            "Stores " + NetworkQuantumStorage.getSizes()[2] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[3] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."
@@ -475,7 +487,7 @@ public class NetworksSlimefunItemStacks {
             new ItemStack(Material.BROWN_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (2M)",
-            "Stores " + NetworkQuantumStorage.getSizes()[3] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[4] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."
@@ -486,7 +498,7 @@ public class NetworksSlimefunItemStacks {
             new ItemStack(Material.BLACK_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (16M)",
-            "Stores " + NetworkQuantumStorage.getSizes()[4] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[5] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."
@@ -497,7 +509,7 @@ public class NetworksSlimefunItemStacks {
             new ItemStack(Material.PURPLE_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (134M)",
-            "Stores " + NetworkQuantumStorage.getSizes()[5] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[6] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."
@@ -508,7 +520,7 @@ public class NetworksSlimefunItemStacks {
             new ItemStack(Material.MAGENTA_TERRACOTTA),
             Theme.MACHINE,
             "Network Quantum Storage (1B)",
-            "Stores " + NetworkQuantumStorage.getSizes()[6] + " items",
+            "Stores " + NetworkQuantumStorage.getSizes()[7] + " items",
             "",
             "Stores items in mass quantities within",
             "a quantum singularity."

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
@@ -46,6 +46,7 @@ import java.util.Map;
 public class NetworkQuantumStorage extends SlimefunItem implements DistinctiveItem {
 
     private static final int[] SIZES = new int[]{
+        512,
         4096,
         32768,
         262144,


### PR DESCRIPTION
Quantum Storage for networks is really useful because they're treated as machines. They have so many usages that aren't just as network storage, but can be used to transfer items between networks while being connected to both with a monitor and a network pusher. This flexibility makes organising network systems and node counts much easier and it's one of the major benefits of Quantum Storages.

Unfortunately, the smallest is 4096 items, which is quite a lot in certain circumstances to have "backed up" in crafting.

Now the Network Greedy Block is useful, but unfortunately works as a network block and would connect multiple networks together - which means it doesn't work for almost all usages that quantums can support.

I've placed an even smaller quantum storage in this PR for review and hopefully addition that would mean not having to autocraft 4k of an item to have it "in reserve" if it's target network becomes full.