### PR TITLE
Disable NetworkDirectional from showing Bedrock

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
@@ -333,7 +333,7 @@ public abstract class NetworkDirectional extends NetworkObject {
 
     @Nonnull
     public static ItemStack getDirectionalSlotPane(@Nonnull BlockFace blockFace, @Nonnull Material blockMaterial, boolean active) {
-        if (blockMaterial.isItem() && !blockMaterial.isAir()) {
+        if (blockMaterial.isItem() && !blockMaterial.isAir() && blockMaterial != Material.BEDROCK)) {
             final ItemStack displayStack = new CustomItemStack(
                 blockMaterial,
                 Theme.PASSIVE + "Direction " + blockFace.name() + " (" + blockMaterial.name() + ")"


### PR DESCRIPTION
Due to Slimefun's Blockstorage issues: If a NetworkDirectional machine is able to see bedrock, and that machine has a Blockstorage issue, users can end up with actual Bedrock item.

This fixes it by adding a check in the `getDirectionalSlotPane` method.