### PR TITLE
[Chore] Update NetworkRoot & NetworkProbe to include all new NodeTypes

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/network/NetworkRoot.java
+++ b/src/main/java/io/github/sefiraat/networks/network/NetworkRoot.java
@@ -46,12 +46,18 @@ public class NetworkRoot extends NetworkNode {
     private final Set<Location> wipers = ConcurrentHashMap.newKeySet();
     private final Set<Location> grabbers = ConcurrentHashMap.newKeySet();
     private final Set<Location> pushers = ConcurrentHashMap.newKeySet();
+    private final Set<Location> cutters = ConcurrentHashMap.newKeySet();
+    private final Set<Location> pasters = ConcurrentHashMap.newKeySet();
+    private final Set<Location> vacuums = ConcurrentHashMap.newKeySet();
     private final Set<Location> purgers = ConcurrentHashMap.newKeySet();
     private final Set<Location> crafters = ConcurrentHashMap.newKeySet();
     private final Set<Location> powerNodes = ConcurrentHashMap.newKeySet();
+    private final Set<Location> powerOutlets = ConcurrentHashMap.newKeySet();
     private final Set<Location> powerDisplays = ConcurrentHashMap.newKeySet();
     private final Set<Location> encoders = ConcurrentHashMap.newKeySet();
     private final Set<Location> greedyBlocks = ConcurrentHashMap.newKeySet();
+    private final Set<Location> wirelessTransmitters = ConcurrentHashMap.newKeySet();
+    private final Set<Location> wirelessReceivers = ConcurrentHashMap.newKeySet();
 
     private Set<BarrelIdentity> barrels = null;
 
@@ -80,12 +86,18 @@ public class NetworkRoot extends NetworkNode {
             case WIPER -> wipers.add(location);
             case GRABBER -> grabbers.add(location);
             case PUSHER -> pushers.add(location);
+            case CUTTER -> cutters.add(location);
+            case PASTER -> pasters.add(location);
+            case VACUUM -> vacuums.add(location);
             case PURGER -> purgers.add(location);
             case CRAFTER -> crafters.add(location);
             case POWER_NODE -> powerNodes.add(location);
+            case POWER_OUTLET -> powerOutlets.add(location);
             case POWER_DISPLAY -> powerDisplays.add(location);
             case ENCODER -> encoders.add(location);
             case GREEDY_BLOCK -> greedyBlocks.add(location);
+            case WIRELESS_TRANSMITTER -> wirelessTransmitters.add(location);
+            case WIRELESS_RECEIVER -> wirelessReceivers.add(location);
         }
     }
 
@@ -155,6 +167,18 @@ public class NetworkRoot extends NetworkNode {
         return this.pushers;
     }
 
+    public Set<Location> getCutters() {
+        return this.cutters;
+    }
+
+    public Set<Location> getPasters() {
+        return this.pasters;
+    }
+
+    public Set<Location> getVacuums() {
+        return this.vacuums;
+    }
+
     public Set<Location> getPurgers() {
         return this.purgers;
     }
@@ -167,12 +191,28 @@ public class NetworkRoot extends NetworkNode {
         return this.powerNodes;
     }
 
+    public Set<Location> getPowerOutlets() {
+        return this.powerOutlets;
+    }
+
     public Set<Location> getPowerDisplays() {
         return this.powerDisplays;
     }
 
     public Set<Location> getEncoders() {
         return this.encoders;
+    }
+
+    public Set<Location> getGreedyBlockLocations() {
+        return this.greedyBlocks;
+    }
+
+    public Set<Location> getWirelessTransmitters() {
+        return this.wirelessTransmitters;
+    }
+
+    public Set<Location> getWirelessReceivers() {
+        return this.wirelessReceivers;
     }
 
     @Nonnull

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkProbe.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkProbe.java
@@ -63,11 +63,19 @@ public class NetworkProbe extends SlimefunItem implements CanCooldown {
             final int wipers = root.getWipers().size();
             final int grabbers = root.getGrabbers().size();
             final int pushers = root.getPushers().size();
+            final int cutters = root.getCutters().size();
+            final int pasters = root.getPasters().size();
+            final int vacuums = root.getVacuums().size();
             final int purgers = root.getPurgers().size();
             final int crafters = root.getCrafters().size();
             final int powerNodes = root.getPowerNodes().size();
+            final int powerOutlets = root.getPowerOutlets().size();
             final int powerDisplays = root.getPowerDisplays().size();
             final int encoders = root.getEncoders().size();
+            final int greedyBlocks = root.getGreedyBlockLocations().size();
+            final int wirelessTransmitters = root.getWirelessTransmitters().size();
+            final int wirelessReceivers = root.getWirelessReceivers().size();
+            final long rootPower = root.getRootPower();
 
             final Map<ItemStack, Integer> allNetworkItems = root.getAllNetworkItems();
             final int distinctItems = allNetworkItems.size();
@@ -93,13 +101,25 @@ public class NetworkProbe extends SlimefunItem implements CanCooldown {
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Wipers", p, wipers}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Grabbers", p, grabbers}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Pushers", p, pushers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Cutters", p, cutters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Pasters", p, pasters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Vacuums", p, vacuums}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Purgers", p, purgers}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Crafters", p, crafters}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Power Nodes", p, powerNodes}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Power Outlets", p, powerOutlets}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Power Displays", p, powerDisplays}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Encoders", p, encoders}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Greedy Blocks", p, greedyBlocks}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Wireless Transmitters", p, wirelessTransmitters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Wireless Receivers", p, wirelessReceivers}, new StringBuffer(), null).toString());
+
+            player.sendMessage("------------------------------");
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Distinct Items", p, distinctItems}, new StringBuffer(), null).toString());
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Total Items", p, totalItems}, new StringBuffer(), null).toString());
+
+            player.sendMessage("------------------------------");
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Root Power", p, rootPower}, new StringBuffer(), null).toString());
 
             player.sendMessage("------------------------------");
             player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "Total Nodes", p, nodeCount + "/" + root.getMaxNodes()}, new StringBuffer(), null).toString());


### PR DESCRIPTION
Like the title says, I added all of the specific `Set<Location>`'s for node types following the previous pattern, I did it in the order of the NodeType enum as that seemed to be the previous order. I also added all of the getter methods for the new sets.
- I also added getter for the greedy block set however the name had to break the format due to the previously existing method that returned a set of the blockmenus.

Then I added all of their respective lines to the NetworkProbe network summary as well as adding a new spacer between the item count and node count parts and then a spacer and adding the root power (I can revert those changes if requested)

I haven't actually tested these yet if you would like me too, I just used the node and saw that it didn't show all of the new things so thought I'd make a PR, if it's intentional or not updated yet because you plan on changing on these systems work I can close the PR no problem!