### PR TITLE
[Chore] Prevent Quantum Storages in Quantum Storages

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
@@ -373,7 +373,8 @@ public class NetworkQuantumStorage extends SlimefunItem implements DistinctiveIt
     private static boolean isBlacklisted(@Nonnull ItemStack itemStack) {
         return itemStack.getType() == Material.AIR
             || itemStack.getType().getMaxDurability() < 0
-            || Tag.SHULKER_BOXES.isTagged(itemStack.getType());
+            || Tag.SHULKER_BOXES.isTagged(itemStack.getType())
+            || SlimefunItem.getByItem(itemStack) instanceof NetworkQuantumStorage;
     }
 
     @ParametersAreNonnullByDefault


### PR DESCRIPTION
Does what it says, I could modify this system to be expandable for just string ids if you in the future need to disable other slimefun items but this is it for now