### PR TITLE
[Fix] Item Overflowing

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkEncoder.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkEncoder.java
@@ -161,7 +161,7 @@ public class NetworkEncoder extends NetworkObject {
             return;
         }
 
-        final ItemStack blueprintClone = StackUtils.getAsQuantity(blueprint, 1);
+        final ItemStack blueprintClone = StackUtils.getAsOne(blueprint);
 
         blueprint.setAmount(blueprint.getAmount() - 1);
         CraftingBlueprint.setBlueprint(blueprintClone, inputs, crafted);

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkConfigurator.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkConfigurator.java
@@ -79,7 +79,7 @@ public class NetworkConfigurator extends SlimefunItem {
             for (int slot : directional.getItemSlots()) {
                 final ItemStack possibleStack = blockMenu.getItemInSlot(slot);
                 if (possibleStack != null) {
-                    itemStacks[i] = StackUtils.getAsQuantity(blockMenu.getItemInSlot(slot), 1);
+                    itemStacks[i] = StackUtils.getAsOne(blockMenu.getItemInSlot(slot));
                 }
                 i++;
             }

--- a/src/main/java/io/github/sefiraat/networks/utils/NetworkUtils.java
+++ b/src/main/java/io/github/sefiraat/networks/utils/NetworkUtils.java
@@ -64,7 +64,7 @@ public class NetworkUtils {
                     boolean worked = false;
                     for (ItemStack stack : player.getInventory()) {
                         if (StackUtils.itemsMatch(stack, templateStack)) {
-                            final ItemStack stackClone = StackUtils.getAsQuantity(stack, 1);
+                            final ItemStack stackClone = StackUtils.getAsOne(stack);
                             stack.setAmount(stack.getAmount() - 1);
                             blockMenu.replaceExistingItem(directional.getItemSlots()[i], stackClone);
                             player.sendMessage(Theme.SUCCESS + "Item [" + i + "]: " + Theme.PASSIVE + "Item added into filter");

--- a/src/main/java/io/github/sefiraat/networks/utils/StackUtils.java
+++ b/src/main/java/io/github/sefiraat/networks/utils/StackUtils.java
@@ -34,6 +34,11 @@ import java.util.Optional;
 public class StackUtils {
 
     @Nonnull
+    public static ItemStack getAsOne(@Nonnull ItemStack itemStack) {
+        return getAsQuantity(itemStack, 1);
+    }
+
+    @Nonnull
     public static ItemStack getAsQuantity(@Nonnull ItemStack itemStack, int amount) {
         ItemStack clone = itemStack.clone();
         clone.setAmount(amount);


### PR DESCRIPTION
Yesterday a player on MetaMechanists reported their grid showing their cobblestone in the negative billions, indicating the display had overflown (not the actual amount as they could still withdraw items), so today I worked on fixing the bug.

First I re-did the `NetworkRoot#getAllNetworkItems` method to use NumberUtils#flowSafeAddition instead of the manual method using longs being used, also just cleaning up the method by using `Map#compute`, when that didn't fix it (which I didn't expect it to but did it regardless) I did a little more debugging and found the problem was actually that the `BarrelIdentity#getAmount` had already overflowed, so I tracked it down to be the `NetworkRoot#getNetworkStorage` and `NetworkRoot#getInfinityBarrel` methods, both add the stored amount **and** the amount in the output slot, so if either have a stored amount of integer max when you add the output amount it overflows. After finding that out I just made it use flow safe addition and also moved around a couple of guard statements to avoid unnecessary logic. Afterwards I noticed that in a lot of places there was a call to StackUtils#getAsQuantity(itemStack, 1) and in some spots there was just a replication of that logic (itemStack.clone(), clone.setAmount(1), so I added a method overload, `StackUtils#getAsOne` and replaced the usages and logic replications with it.

After testing in game with a infinite quantum storage and a 4k quantum storage both full with cobble completely and inputs and output slots filled, before these changes it overflows, after these changes it does not :+1: