### PR TITLE
fix remove potions without basedata from grid/storages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>0a7fea8</version>
+            <version>RC-37</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/sefiraat/networks/utils/StackUtils.java
+++ b/src/main/java/io/github/sefiraat/networks/utils/StackUtils.java
@@ -268,9 +268,13 @@ public class StackUtils {
 
         // Potion
         if (metaOne instanceof PotionMeta instanceOne && metaTwo instanceof PotionMeta instanceTwo) {
-            if (!instanceOne.getBasePotionData().equals(instanceTwo.getBasePotionData())) {
-                return true;
+
+            if((instanceOne.getBasePotionData() != null) && (instanceTwo.getBasePotionData() != null)) {
+                if (!instanceOne.getBasePotionData().equals(instanceTwo.getBasePotionData())) {
+                    return true;
+                }
             }
+
             if (instanceOne.hasCustomEffects() != instanceTwo.hasCustomEffects()) {
                 return true;
             }


### PR DESCRIPTION
fix problem of:

```
[15:09:27 ERROR]: Could not pass event InventoryClickEvent to Slimefun vDev - 1157
java.lang.NullPointerException: Cannot invoke "org.bukkit.potion.PotionData.equals(Object)" because the return value of "org.bukkit.inventory.meta.PotionMeta.getBasePotionData()" is null
	at Networks - DEV 50 (git 3de3c).jar/io.github.sefiraat.networks.utils.StackUtils.canQuickEscapeMetaVariant(StackUtils.java:271) ~[Networks - DEV 50 (git 3de3c).jar:?]
	at Networks - DEV 50 (git 3de3c).jar/io.github.sefiraat.networks.utils.StackUtils.itemsMatch(StackUtils.java:80) ~[Networks - DEV 50 (git 3de3c).jar:?]
	at Networks - DEV 50 (git 3de3c).jar/io.github.sefiraat.networks.network.NetworkRoot.getItemStack(NetworkRoot.java:443) ~[Networks - DEV 50 (git 3de3c).jar:?]
	at Networks - DEV 50 (git 3de3c).jar/io.github.sefiraat.networks.slimefun.network.grid.AbstractGrid.addToCursor(AbstractGrid.java:308) ~[Networks - DEV 50 (git 3de3c).jar:?]
	at Networks - DEV 50 (git 3de3c).jar/io.github.sefiraat.networks.slimefun.network.grid.AbstractGrid.retrieveItem(AbstractGrid.java:278) ~[Networks - DEV 50 (git 3de3c).jar:?]
	at Networks - DEV 50 (git 3de3c).jar/io.github.sefiraat.networks.slimefun.network.grid.AbstractGrid.lambda$updateDisplay$1(AbstractGrid.java:196) ~[Networks - DEV 50 (git 3de3c).jar:?]
	at Slimefun4-Dev.jar/me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.MenuListener.onClick(MenuListener.java:53) ~[Slimefun4-Dev.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor29.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:77) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:1.20.6-2233-0d6766e]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3260) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:69) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:33) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:55) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:151) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1546) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:195) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:125) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1523) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1446) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:135) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1412) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1273) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:326) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```