### PR TITLE
Makes Networks compatible with Slimefun's 1.21 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>0a7fea8</version>
+            <version>walshy~mc-1.21-RC-7-g47092df-5828</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/sefiraat/networks/slimefun/NetworksItemGroups.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/NetworksItemGroups.java
@@ -20,7 +20,7 @@ public final class NetworksItemGroups {
 
     public static final MainFlexGroup MAIN = new MainFlexGroup(
         Keys.newKey("main"),
-        new CustomItemStack(
+        CustomItemStack.create(
             new ItemStack(Material.BLACK_STAINED_GLASS),
             Theme.MAIN.getColor() + "Networks"
         )
@@ -28,7 +28,7 @@ public final class NetworksItemGroups {
 
     public static final DummyItemGroup MATERIALS = new DummyItemGroup(
         Keys.newKey("materials"),
-        new CustomItemStack(
+        CustomItemStack.create(
             new ItemStack(Material.WHITE_STAINED_GLASS),
             Theme.MAIN.getColor() + "Crafting Materials"
         )
@@ -36,7 +36,7 @@ public final class NetworksItemGroups {
 
     public static final DummyItemGroup TOOLS = new DummyItemGroup(
         Keys.newKey("tools"),
-        new CustomItemStack(
+        CustomItemStack.create(
             new ItemStack(Material.PAINTING),
             Theme.MAIN.getColor() + "Network Management Tools"
         )
@@ -44,7 +44,7 @@ public final class NetworksItemGroups {
 
     public static final DummyItemGroup NETWORK_ITEMS = new DummyItemGroup(
         Keys.newKey("network_items"),
-        new CustomItemStack(
+        CustomItemStack.create(
             new ItemStack(Material.BLACK_STAINED_GLASS),
             Theme.MAIN.getColor() + "Network Items"
         )
@@ -52,7 +52,7 @@ public final class NetworksItemGroups {
 
     public static final DummyItemGroup NETWORK_QUANTUMS = new DummyItemGroup(
         Keys.newKey("network_quantums"),
-        new CustomItemStack(
+        CustomItemStack.create(
             new ItemStack(Material.WHITE_TERRACOTTA),
             Theme.MAIN.getColor() + "Network Quantum Storage Devices"
         )
@@ -60,7 +60,7 @@ public final class NetworksItemGroups {
 
     public static final ItemGroup DISABLED_ITEMS = new HiddenItemGroup(
         Keys.newKey("disabled_items"),
-        new CustomItemStack(
+        CustomItemStack.create(
             new ItemStack(Material.BARRIER),
             Theme.MAIN.getColor() + "Disabled/Removed Items"
         )

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkAutoCrafter.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkAutoCrafter.java
@@ -52,11 +52,11 @@ public class NetworkAutoCrafter extends NetworkObject {
     private static final int BLUEPRINT_SLOT = 10;
     private static final int OUTPUT_SLOT = 16;
 
-    public static final CustomItemStack BLUEPRINT_BACKGROUND_STACK = new CustomItemStack(
+    public static final ItemStack BLUEPRINT_BACKGROUND_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "Crafting Blueprint"
     );
 
-    public static final CustomItemStack OUTPUT_BACKGROUND_STACK = new CustomItemStack(
+    public static final ItemStack OUTPUT_BACKGROUND_STACK = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE, Theme.PASSIVE + "Output"
     );
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
@@ -53,7 +53,7 @@ public class NetworkControlV extends NetworkDirectional {
 
     private final Set<BlockPosition> blockCache = new HashSet<>();
 
-    public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
+    public static final ItemStack TEMPLATE_BACKGROUND_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "Paste items matching template"
     );
 
@@ -166,7 +166,7 @@ public class NetworkControlV extends NetworkDirectional {
 
     @Nullable
     @Override
-    protected CustomItemStack getOtherBackgroundStack() {
+    protected ItemStack getOtherBackgroundStack() {
         return TEMPLATE_BACKGROUND_STACK;
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlX.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlX.java
@@ -52,7 +52,7 @@ public class NetworkControlX extends NetworkDirectional {
 
     private final Set<BlockPosition> blockCache = new HashSet<>();
 
-    public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
+    public static final ItemStack TEMPLATE_BACKGROUND_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE,
         Theme.PASSIVE + "Cut items matching template.",
         Theme.PASSIVE + "Leaving blank will cut anything"
@@ -167,7 +167,7 @@ public class NetworkControlX extends NetworkDirectional {
 
     @Nullable
     @Override
-    protected CustomItemStack getOtherBackgroundStack() {
+    protected ItemStack getOtherBackgroundStack() {
         return TEMPLATE_BACKGROUND_STACK;
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
@@ -276,7 +276,7 @@ public abstract class NetworkDirectional extends NetworkObject {
     }
 
     @Nullable
-    protected CustomItemStack getOtherBackgroundStack() {
+    protected ItemStack getOtherBackgroundStack() {
         return null;
     }
 
@@ -314,7 +314,7 @@ public abstract class NetworkDirectional extends NetworkObject {
 
     @Nonnull
     public static ItemStack getDirectionalSlotPane(@Nonnull BlockFace blockFace, @Nonnull SlimefunItem slimefunItem, boolean active) {
-        final ItemStack displayStack = new CustomItemStack(
+        final ItemStack displayStack = CustomItemStack.create(
             slimefunItem.getItem(),
             Theme.PASSIVE + "Direction " + blockFace.name() + " (" + ChatColor.stripColor(slimefunItem.getItemName()) + ")"
         );
@@ -334,7 +334,7 @@ public abstract class NetworkDirectional extends NetworkObject {
     @Nonnull
     public static ItemStack getDirectionalSlotPane(@Nonnull BlockFace blockFace, @Nonnull Material blockMaterial, boolean active) {
         if (blockMaterial.isItem() && !blockMaterial.isAir()) {
-            final ItemStack displayStack = new CustomItemStack(
+            final ItemStack displayStack = CustomItemStack.create(
                 blockMaterial,
                 Theme.PASSIVE + "Direction " + blockFace.name() + " (" + blockMaterial.name() + ")"
             );
@@ -351,7 +351,7 @@ public abstract class NetworkDirectional extends NetworkObject {
             return displayStack;
         } else {
             Material material = active ? Material.GREEN_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE;
-            return new CustomItemStack(
+            return CustomItemStack.create(
                 material,
                 ChatColor.GRAY + "Set direction: " + blockFace.name()
             );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkEncoder.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkEncoder.java
@@ -48,11 +48,11 @@ public class NetworkEncoder extends NetworkObject {
 
     private static final int CHARGE_COST = 20000;
 
-    public static final CustomItemStack BLUEPRINT_BACK_STACK = new CustomItemStack(
+    public static final ItemStack BLUEPRINT_BACK_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "Blank Blueprint"
     );
 
-    public static final CustomItemStack ENCODE_STACK = new CustomItemStack(
+    public static final ItemStack ENCODE_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "Click to encode when valid"
     );
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkExport.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkExport.java
@@ -39,12 +39,12 @@ public class NetworkExport extends NetworkObject {
     private static final int OUTPUT_ITEM_SLOT = 24;
     private static final int[] OUTPUT_ITEM_BACKDROP = {14, 15, 16, 23, 25, 32, 33, 34};
 
-    private static final CustomItemStack TEST_BACKDROP_STACK = new CustomItemStack(
+    private static final ItemStack TEST_BACKDROP_STACK = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Export Item Matching"
     );
 
-    private static final CustomItemStack OUTPUT_BACKDROP_STACK = new CustomItemStack(
+    private static final ItemStack OUTPUT_BACKDROP_STACK = CustomItemStack.create(
         Material.ORANGE_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Output Slot"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkGreedyBlock.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkGreedyBlock.java
@@ -32,12 +32,12 @@ public class NetworkGreedyBlock extends NetworkObject {
         6,7,8,15,17,24,25,26
     };
 
-    private static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
+    private static final ItemStack TEMPLATE_BACKGROUND_STACK = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Store items matching"
     );
 
-    private static final CustomItemStack STORAGE_BACKGROUND_STACK = new CustomItemStack(
+    private static final ItemStack STORAGE_BACKGROUND_STACK = CustomItemStack.create(
         Material.ORANGE_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Storage"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPowerDisplay.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPowerDisplay.java
@@ -33,7 +33,7 @@ public class NetworkPowerDisplay extends NetworkObject {
     };
     private static final int DISPLAY_SLOT = 4;
 
-    private static final CustomItemStack EMPTY = new CustomItemStack(
+    private static final ItemStack EMPTY = CustomItemStack.create(
         Material.RED_STAINED_GLASS_PANE,
         Theme.CLICK_INFO + "Status",
         Theme.PASSIVE + "Disconnected"
@@ -98,8 +98,8 @@ public class NetworkPowerDisplay extends NetworkObject {
         };
     }
 
-    private static CustomItemStack getChargeStack(long charge) {
-        return new CustomItemStack(
+    private static ItemStack getChargeStack(long charge) {
+        return CustomItemStack.create(
             Material.GREEN_STAINED_GLASS_PANE,
             Theme.CLICK_INFO + "Status",
             Theme.PASSIVE + "Current Network Charge: " + charge + "j"

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPurger.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPurger.java
@@ -39,7 +39,7 @@ public class NetworkPurger extends NetworkObject {
     private static final int TEST_ITEM_SLOT = 13;
     private static final int[] TEST_ITEM_BACKDROP = {3, 4, 5, 12, 14, 21, 22, 23};
 
-    private static final CustomItemStack TEST_BACKDROP_STACK = new CustomItemStack(
+    private static final ItemStack TEST_BACKDROP_STACK = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Purge Item Matching"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPusher.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPusher.java
@@ -37,7 +37,7 @@ public class NetworkPusher extends NetworkDirectional {
     private static final int UP_SLOT = 14;
     private static final int DOWN_SLOT = 32;
 
-    public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
+    public static final ItemStack TEMPLATE_BACKGROUND_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "Push items matching template"
     );
 
@@ -121,7 +121,7 @@ public class NetworkPusher extends NetworkDirectional {
 
     @Nullable
     @Override
-    protected CustomItemStack getOtherBackgroundStack() {
+    protected ItemStack getOtherBackgroundStack() {
         return TEMPLATE_BACKGROUND_STACK;
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
@@ -64,31 +64,31 @@ public class NetworkQuantumStorage extends SlimefunItem implements DistinctiveIt
     public static final int ITEM_SET_SLOT = 13;
     public static final int OUTPUT_SLOT = 7;
 
-    private static final ItemStack BACK_INPUT = new CustomItemStack(
+    private static final ItemStack BACK_INPUT = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE,
         Theme.PASSIVE + "Input"
     );
 
-    private static final ItemStack BACK_ITEM = new CustomItemStack(
+    private static final ItemStack BACK_ITEM = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE,
         Theme.PASSIVE + "Item Stored"
     );
 
-    private static final ItemStack NO_ITEM = new CustomItemStack(
+    private static final ItemStack NO_ITEM = CustomItemStack.create(
         Material.RED_STAINED_GLASS_PANE,
         Theme.ERROR + "No Registered Item",
         Theme.PASSIVE + "Click the icon below while",
         Theme.PASSIVE + "holding an item to register it."
     );
 
-    private static final ItemStack SET_ITEM = new CustomItemStack(
+    private static final ItemStack SET_ITEM = CustomItemStack.create(
         Material.LIME_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Set Item",
         Theme.PASSIVE + "Drag an item on top of this pane to register it.",
         Theme.PASSIVE + "Shift Click to change voiding"
     );
 
-    private static final ItemStack BACK_OUTPUT = new CustomItemStack(
+    private static final ItemStack BACK_OUTPUT = CustomItemStack.create(
         Material.ORANGE_STAINED_GLASS_PANE,
         Theme.PASSIVE + "Output"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumWorkbench.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumWorkbench.java
@@ -42,7 +42,7 @@ public class NetworkQuantumWorkbench extends SlimefunItem {
     private static final int CRAFT_SLOT = 23;
     private static final int OUTPUT_SLOT = 25;
 
-    private static final CustomItemStack CRAFT_BUTTON_STACK = new CustomItemStack(
+    private static final ItemStack CRAFT_BUTTON_STACK = CustomItemStack.create(
         Material.CRAFTING_TABLE,
         Theme.CLICK_INFO + "Click to entangle"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessReceiver.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessReceiver.java
@@ -37,7 +37,7 @@ public class NetworkWirelessReceiver extends NetworkObject {
         3, 4, 5, 12, 14, 21, 22, 23
     };
 
-    private static final CustomItemStack RECEIVED_BACKGROUND_STACK = new CustomItemStack(
+    private static final ItemStack RECEIVED_BACKGROUND_STACK = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Received items"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessTransmitter.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessTransmitter.java
@@ -43,7 +43,7 @@ public class NetworkWirelessTransmitter extends NetworkObject {
         3, 4, 5, 12, 14, 21, 22, 23
     };
 
-    private static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
+    private static final ItemStack TEMPLATE_BACKGROUND_STACK = CustomItemStack.create(
         Material.GREEN_STAINED_GLASS_PANE,
         Theme.SUCCESS + "Transmit items matching"
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
@@ -42,27 +42,27 @@ import java.util.Map;
 
 public abstract class AbstractGrid extends NetworkObject {
 
-    private static final CustomItemStack BLANK_SLOT_STACK = new CustomItemStack(
+    private static final ItemStack BLANK_SLOT_STACK = CustomItemStack.create(
         Material.LIGHT_GRAY_STAINED_GLASS_PANE,
         " "
     );
 
-    private static final CustomItemStack PAGE_PREVIOUS_STACK = new CustomItemStack(
+    private static final ItemStack PAGE_PREVIOUS_STACK = CustomItemStack.create(
         Material.RED_STAINED_GLASS_PANE,
         Theme.CLICK_INFO.getColor() + "Previous Page"
     );
 
-    private static final CustomItemStack PAGE_NEXT_STACK = new CustomItemStack(
+    private static final ItemStack PAGE_NEXT_STACK = CustomItemStack.create(
         Material.RED_STAINED_GLASS_PANE,
         Theme.CLICK_INFO.getColor() + "Next Page"
     );
 
-    private static final CustomItemStack CHANGE_SORT_STACK = new CustomItemStack(
+    private static final ItemStack CHANGE_SORT_STACK = CustomItemStack.create(
         Material.BLUE_STAINED_GLASS_PANE,
         Theme.CLICK_INFO.getColor() + "Change Sort Order"
     );
 
-    private static final CustomItemStack FILTER_STACK = new CustomItemStack(
+    private static final ItemStack FILTER_STACK = CustomItemStack.create(
         Material.NAME_TAG,
         Theme.CLICK_INFO.getColor() + "Set Filter (Right Click to Clear)"
     );
@@ -350,23 +350,23 @@ public abstract class AbstractGrid extends NetworkObject {
 
     protected abstract int getFilterSlot();
 
-    protected CustomItemStack getBlankSlotStack() {
+    protected ItemStack getBlankSlotStack() {
         return BLANK_SLOT_STACK;
     }
 
-    protected CustomItemStack getPagePreviousStack() {
+    protected ItemStack getPagePreviousStack() {
         return PAGE_PREVIOUS_STACK;
     }
 
-    protected CustomItemStack getPageNextStack() {
+    protected ItemStack getPageNextStack() {
         return PAGE_NEXT_STACK;
     }
 
-    protected CustomItemStack getChangeSortStack() {
+    protected ItemStack getChangeSortStack() {
         return CHANGE_SORT_STACK;
     }
 
-    protected CustomItemStack getFilterStack() {
+    protected ItemStack getFilterStack() {
         return FILTER_STACK;
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/NetworkCraftingGrid.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/NetworkCraftingGrid.java
@@ -50,7 +50,7 @@ public class NetworkCraftingGrid extends AbstractGrid {
     private static final int CRAFT_BUTTON_SLOT = 34;
     private static final int CRAFT_OUTPUT_SLOT = 43;
 
-    private static final CustomItemStack CRAFT_BUTTON_STACK = new CustomItemStack(
+    private static final ItemStack CRAFT_BUTTON_STACK = CustomItemStack.create(
         Material.CRAFTING_TABLE,
         Theme.CLICK_INFO.getColor() + "Craft",
         Theme.CLICK_INFO + "Left Click: " + Theme.PASSIVE + "Try to Craft",

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkConfigurator.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkConfigurator.java
@@ -2,7 +2,6 @@ package io.github.sefiraat.networks.slimefun.tools;
 
 import de.jeff_media.morepersistentdatatypes.DataType;
 import io.github.sefiraat.networks.slimefun.network.NetworkDirectional;
-import io.github.sefiraat.networks.slimefun.network.NetworkPusher;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.NetworkUtils;
 import io.github.sefiraat.networks.utils.StackUtils;

--- a/src/main/java/io/github/sefiraat/networks/utils/Theme.java
+++ b/src/main/java/io/github/sefiraat/networks/utils/Theme.java
@@ -132,7 +132,7 @@ public enum Theme {
         }
         finalLore.add("");
         finalLore.add(applyThemeToString(Theme.CLICK_INFO, themeType.getLoreLine()));
-        return new CustomItemStack(
+        return CustomItemStack.create(
             material,
             Theme.applyThemeToString(themeType, name),
             finalLore.toArray(new String[finalLore.size() - 1])


### PR DESCRIPTION
Does not use CustomItemStack initialization anymore

Note that I do not expect this to be merged until Slimefun officially updates, and when it does, the version dependency in pom.xml will have to be changed.